### PR TITLE
Fix board opening

### DIFF
--- a/javascript/background.js
+++ b/javascript/background.js
@@ -1,10 +1,14 @@
+function startWip(tabId) {
+    chrome.tabs.sendMessage(tabId, { action: "start" });
+}
+
 function updateWip(tabId) {
     chrome.tabs.sendMessage(tabId, { action: "update" });
 }
 
 (function () {
     chrome.webNavigation.onCompleted.addListener((details) => {
-        if (details.url.startsWith("https://trello.com/b/")) updateWip(details.tabId);
+        if (details.url.startsWith("https://trello.com/b/")) startWip(details.tabId);
     });
 
     chrome.webRequest.onCompleted.addListener((details) => {
@@ -13,8 +17,7 @@ function updateWip(tabId) {
         urls: [
             "https://trello.com/*/lists/*",
             "https://trello.com/*/lists",
-            "https://trello.com/*/cards/*",
-            "https://trello.com/*/cards"
+            "https://trello.com/*/card/*"
         ]
     });
 }());

--- a/javascript/wip.js
+++ b/javascript/wip.js
@@ -1,4 +1,4 @@
-const wipRegex = /\[(\d)?-?(\d)\]/g;
+const wipRegex = /\[(?:(\d+)-)?(\d+)\]/s;
 
 function findColumns() {
     return Array.from(document.querySelectorAll('div.list'));
@@ -69,6 +69,22 @@ function highlightColumnsWithWip() {
     });
 }
 
+let validateLoadingCount = 0;
+
+function waitLoading(resolve) {
+    const pluginButtons = document.querySelector(".board-header-plugin-btns");
+    if (pluginButtons && pluginButtons.children.length > 0) {
+        resolve();
+        return;
+    }
+
+    if (validateLoadingCount > 60) return;
+
+    validateLoadingCount++;
+    setTimeout(function() { waitLoading(resolve) }, 500);
+}
+
 chrome.runtime.onMessage.addListener(function (request) {
+    if (request.action === "start") return new Promise(waitLoading).then(highlightColumnsWithWip);
     if (request.action === "update") return highlightColumnsWithWip();
 });

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Trello Kanban",
-  "version": "1.1",
+  "version": "1.1.1",
   "description": "Add card number, list cards counter and wip limit",
   "manifest_version": 2,
   "permissions": [


### PR DESCRIPTION
# Context
The plugin starts too early for boards with lots of lists and cards.

# Solution
This PR implements a throttling on the extension loading by checking the plugin buttons component of the page.